### PR TITLE
ci: add allowed clippy lints

### DIFF
--- a/.github/workflows/security_analysis.yml
+++ b/.github/workflows/security_analysis.yml
@@ -112,10 +112,10 @@ jobs:
         continue-on-error: ${{ matrix.allowTestsToFail }}
         working-directory: ${{ matrix.path }}
         run: |
-          cargo clippy --all-targets --workspace --no-deps --lib -- -D clippy::all -D clippy::pedantic \
+          cargo clippy --all-targets --workspace --no-deps --lib -- -D clippy::all -D clippy::pedantic -D clippy::nursery \
           -A clippy::missing_errors_doc -A clippy::missing_panics_doc \
           -A clippy::must_use_candidate -A clippy::unreadable_literal \
-          -A clippy::similar_names
+          -A clippy::similar_names -A clippy::too_long_first_doc_paragraph
 
       - name: Setup Go
         uses: WillAbides/setup-go-faster@v1.14.0

--- a/.github/workflows/security_analysis.yml
+++ b/.github/workflows/security_analysis.yml
@@ -114,7 +114,8 @@ jobs:
         run: |
           cargo clippy --all-targets --workspace --no-deps --lib -- -D clippy::all -D clippy::pedantic \
           -A clippy::missing_errors_doc -A clippy::missing_panics_doc \
-          -A clippy::must_use_candidate
+          -A clippy::must_use_candidate -A clippy::unreadable_literal \
+          -A clippy::similar_names
 
       - name: Setup Go
         uses: WillAbides/setup-go-faster@v1.14.0


### PR DESCRIPTION
The PR adds allowed clippy lints `clippy::unreadable_literal` and `clippy::similar_names`. It will allow to merge the [PR](https://github.com/aurora-is-near/aurora-engine/pull/997).