### PR TITLE
Use public runner

### DIFF
--- a/.github/workflows/check_emails.yml
+++ b/.github/workflows/check_emails.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   check_emails:
     name: Check committer(s) email(s)
-    runs-on: [self-hosted, light]
+    runs-on: ubuntu-latest
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workflow to use the default GitHub-hosted runner environment for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->